### PR TITLE
Add diffutils back to Centos 8 container

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,5 +10,5 @@ The image tags are:
 - lsstdm/scipipe-base:7
 - lsstdm/scipipe-base:8
 
-The Dockerhub repo is set up to automatically build this images from
+The Dockerhub repo is set up to automatically build these images from
 this git repo.

--- a/README.md
+++ b/README.md
@@ -5,3 +5,10 @@ This repository contains Dockerfiles for science pipelines containers.
 
 The base-7 and base-8 images are available under 
 https://hub.docker.com/r/lsstdm/scipipe-base.
+
+The image tags are:
+- lsstdm/scipipe-base:7
+- lsstdm/scipipe-base:8
+
+The Dockerhub repo is set up to automatically build this images from
+this git repo.

--- a/base-7/Dockerfile
+++ b/base-7/Dockerfile
@@ -1,7 +1,7 @@
 FROM centos:7
 LABEL MAINTAINER Brian Van Klaveren <bvan@slac.stanford.edu>
 
-ENV SUMMARY="Rubin Observatory Base centos 7 image for building software" \
+ENV SUMMARY="Rubin Observatory Base CentOS 7 image for building software" \
     DESCRIPTION="This is the base image required for conda, lsstsw, and \
 newinstall workflows"
 

--- a/base-8/Dockerfile
+++ b/base-8/Dockerfile
@@ -1,7 +1,7 @@
 FROM centos:8
 LABEL MAINTAINER Brian Van Klaveren <bvan@slac.stanford.edu>
 
-ENV SUMMARY="Rubin Observatory base centos 8 image for building software" \
+ENV SUMMARY="Rubin Observatory base CentOS 8 image for building software" \
     DESCRIPTION="This is the base image required for conda, lsstsw, and \
 newinstall workflows"
 

--- a/base-8/Dockerfile
+++ b/base-8/Dockerfile
@@ -12,7 +12,7 @@ LABEL name="lsstdm/scipipe-base:8" \
       io.k8s.description="$DESCRIPTION" \
       io.k8s.display-name="Rubin Observatory centos 8 container" 
 
-RUN INSTALL_PKGS="git patch" && \
+RUN INSTALL_PKGS="git patch diffutils" && \
     yum install -y --setopt=tsflags=nodocs ${INSTALL_PKGS} && \
     rpm -V ${INSTALL_PKGS} && \
     yum -y clean all --enablerepo='*'


### PR DESCRIPTION
This PR adds diffutils back to CentOS 8, which is used to check against changes in the container environment.

Documentation is also updated to reflect the use of automatic builds in Dockerhub.